### PR TITLE
Addind option to choose which default movement setting to use

### DIFF
--- a/HybridCamera/ConfigWindow.cs
+++ b/HybridCamera/ConfigWindow.cs
@@ -5,28 +5,23 @@ using System.Numerics;
 
 namespace HybridCamera;
 
-public class ConfigWindow : WindowWrapper
-{
+public class ConfigWindow : WindowWrapper {
     public static string ConfigWindowName = "Hybrid Camera Config";
     private static Vector2 MinSize = new Vector2(500, 320);
 
-    public ConfigWindow() : base(ConfigWindowName, MinSize) { }
+    public ConfigWindow() : base(ConfigWindowName, MinSize) {}
 
-    private void DrawMoveModeConditionOption(string descriptor, ref MoveModeCondition cfg, string tooltip)
-    {
+    private void DrawMoveModeConditionOption(string descriptor, ref MoveModeCondition cfg, string tooltip) {
         float charwidth = ImGui.CalcTextSize("FF").X;
 
         ImGui.Checkbox($"Force {descriptor} to use mode: ", ref cfg.condition);
         WindowDrawHelpers.DrawTooltip(tooltip);
         ImGui.SameLine();
         ImGui.SetNextItemWidth(charwidth * 8);
-        if (ImGui.BeginCombo($"Movement Mode###{descriptor}combo", cfg.mode.ToString()))
-        {
-            for (int index = 0; index < (int)MovementMode.Count; index++)
-            {
+        if (ImGui.BeginCombo($"Movement Mode###{descriptor}combo", cfg.mode.ToString())) {
+            for (int index = 0; index < (int)MovementMode.Count; index++) {
                 ImGui.SetNextItemWidth(charwidth * 8);
-                if (ImGui.Selectable(((MovementMode)index).ToString(), index == (int)cfg.mode))
-                {
+                if (ImGui.Selectable(((MovementMode)index).ToString(), index == (int)cfg.mode)) {
                     cfg.mode = (MovementMode)index;
                 }
             }
@@ -35,21 +30,18 @@ public class ConfigWindow : WindowWrapper
         WindowDrawHelpers.DrawTooltip(tooltip);
     }
 
-    public override void Draw()
-    {
+    public override void Draw() {
         VirtualKey key;
         float charwidth = ImGui.CalcTextSize("FF").X;
         bool changed = false;
 
-        if (!Globals.Config.shutUpConfigHelp)
-        {
+        if (!Globals.Config.shutUpConfigHelp) {
             ImGui.TextWrapped("Before using this plugin, I suggest making the following changes to your character config:");
             ImGui.TextWrapped("- Under Character Configuration -> Legacy Type, toggle the option \"Disable camera pivot\" on");
             ImGui.TextWrapped("- Under Character Configuration -> Camera Controls, set the option \"Standard Type Camera Auto-adjustment\" to \"Never\", and subsequently disable \"Enable Y-axis auto-adjustment\"");
             ImGui.TextWrapped("Additionally, you should try using strafe over turn movement, and vice-versa.");
             ImGui.TextWrapped("This means going into your keybinds and changing your primary movement keys from turn to strafe, and decide which feels the best to use while under the influence of this plugin.");
-            if (ImGui.Button("Ok!"))
-            {
+            if (ImGui.Button("Ok!")) {
                 Globals.Config.shutUpConfigHelp = true;
             }
             ImGui.Separator();
@@ -101,18 +93,14 @@ public class ConfigWindow : WindowWrapper
         }
 
         // Noone should really need to use this, so I'm just gonna hide it behind a config variable
-        if (Globals.Config.ShowExperimental)
-        {
+        if (Globals.Config.ShowExperimental) {
             ImGui.Separator();
             ImGui.TextDisabled("Experimental");
             ImGui.SetNextItemWidth(charwidth * 9);
-            if (ImGui.BeginCombo($"Use turning on camera rotate###turncameraturn", Globals.Config.useTurnOnCameraTurn.ToString()))
-            {
-                for (int index = 0; index < (int)TurnOnCameraTurn.Count; index++)
-                {
+            if (ImGui.BeginCombo($"Use turning on camera rotate###turncameraturn", Globals.Config.useTurnOnCameraTurn.ToString())) {
+                for (int index = 0; index < (int)TurnOnCameraTurn.Count; index++) {
                     ImGui.SetNextItemWidth(charwidth * 8);
-                    if (ImGui.Selectable(((TurnOnCameraTurn)index).ToString(), index == (int)Globals.Config.useTurnOnCameraTurn))
-                    {
+                    if (ImGui.Selectable(((TurnOnCameraTurn)index).ToString(), index == (int)Globals.Config.useTurnOnCameraTurn)) {
                         Globals.Config.useTurnOnCameraTurn = (TurnOnCameraTurn)index;
                         KeybindHook.cameraTurnMode = Globals.Config.useTurnOnCameraTurn;
                         changed = true;
@@ -123,14 +111,11 @@ public class ConfigWindow : WindowWrapper
             WindowDrawHelpers.DrawTooltip("Tells the game that you are turning instead of strafing when you are turning the camera. You probably want this disabled.");
         }
 
-        if (changed)
-        {
-            if (Globals.Config.useTurnOnFrontpedal == false && Globals.Config.useTurnOnBackpedal == false && Globals.Config.useTurnOnCameraTurn == TurnOnCameraTurn.None && KeybindHook.Enabled)
-            {
+        if (changed) {
+            if (Globals.Config.useTurnOnFrontpedal == false && Globals.Config.useTurnOnBackpedal == false && Globals.Config.useTurnOnCameraTurn == TurnOnCameraTurn.None && KeybindHook.Enabled) {
                 KeybindHook.DisableHook();
             }
-            else if (KeybindHook.Enabled == false)
-            {
+            else if (KeybindHook.Enabled == false) {
                 KeybindHook.EnableHook();
             }
         }
@@ -139,20 +124,16 @@ public class ConfigWindow : WindowWrapper
 
         ImGui.TextDisabled("Add and remove the keys for legacy mode below");
 
-        for (int index = 0; index < Globals.Config.legacyModeKeyList.Count; index++)
-        {
+        for (int index = 0; index < Globals.Config.legacyModeKeyList.Count; index++) {
             key = Globals.Config.legacyModeKeyList[index];
             ImGui.SetNextItemWidth(charwidth * 4);
-            if (ImGui.BeginCombo("key##" + index.ToString() + "_" + key.ToString(), key.ToString()))
-            {
+            if (ImGui.BeginCombo("key##" + index.ToString() + "_" + key.ToString(), key.ToString())) {
                 VirtualKey[] validKeys = (VirtualKey[])Service.KeyState.GetValidVirtualKeys();
 
-                for (int qndex = 0; qndex < validKeys.Length; qndex++)
-                {
+                for (int qndex = 0; qndex < validKeys.Length; qndex++) {
                     bool selected = key == validKeys[qndex];
                     ImGui.SetNextItemWidth(charwidth * 12);
-                    if (ImGui.Selectable(validKeys[qndex].ToString() + "##dropdown_" + index.ToString() + "_key_" + validKeys[qndex].ToString(), selected))
-                    {
+                    if (ImGui.Selectable(validKeys[qndex].ToString() + "##dropdown_" + index.ToString() + "_key_" + validKeys[qndex].ToString(), selected)) {
                         Globals.Config.legacyModeKeyList[index] = validKeys[qndex];
                     }
                 }
@@ -160,16 +141,14 @@ public class ConfigWindow : WindowWrapper
             }
             ImGui.SameLine();
             ImGui.SetNextItemWidth(charwidth * 4);
-            if (ImGui.Button("-##dropdown_" + index.ToString() + "_delete"))
-            {
+            if (ImGui.Button("-##dropdown_" + index.ToString() + "_delete")) {
                 Globals.Config.legacyModeKeyList.RemoveAt(index);
                 break;
             }
         }
         ImGui.SameLine();
         ImGui.SetNextItemWidth(charwidth * 4);
-        if (ImGui.Button("+##dropdown_add_new"))
-        {
+        if (ImGui.Button("+##dropdown_add_new")) {
             Globals.Config.legacyModeKeyList.Add(VirtualKey.SPACE);
         }
 

--- a/HybridCamera/ConfigWindow.cs
+++ b/HybridCamera/ConfigWindow.cs
@@ -5,23 +5,28 @@ using System.Numerics;
 
 namespace HybridCamera;
 
-public class ConfigWindow : WindowWrapper {
+public class ConfigWindow : WindowWrapper
+{
     public static string ConfigWindowName = "Hybrid Camera Config";
     private static Vector2 MinSize = new Vector2(500, 320);
 
-    public ConfigWindow() : base(ConfigWindowName, MinSize) {}
+    public ConfigWindow() : base(ConfigWindowName, MinSize) { }
 
-    private void DrawMoveModeConditionOption(string descriptor, ref MoveModeCondition cfg, string tooltip) {
+    private void DrawMoveModeConditionOption(string descriptor, ref MoveModeCondition cfg, string tooltip)
+    {
         float charwidth = ImGui.CalcTextSize("FF").X;
 
         ImGui.Checkbox($"Force {descriptor} to use mode: ", ref cfg.condition);
         WindowDrawHelpers.DrawTooltip(tooltip);
         ImGui.SameLine();
         ImGui.SetNextItemWidth(charwidth * 8);
-        if (ImGui.BeginCombo($"Movement Mode###{descriptor}combo", cfg.mode.ToString())) {
-            for (int index = 0; index < (int)MovementMode.Count; index++) {
+        if (ImGui.BeginCombo($"Movement Mode###{descriptor}combo", cfg.mode.ToString()))
+        {
+            for (int index = 0; index < (int)MovementMode.Count; index++)
+            {
                 ImGui.SetNextItemWidth(charwidth * 8);
-                if (ImGui.Selectable(((MovementMode)index).ToString(), index == (int)cfg.mode)) {
+                if (ImGui.Selectable(((MovementMode)index).ToString(), index == (int)cfg.mode))
+                {
                     cfg.mode = (MovementMode)index;
                 }
             }
@@ -30,24 +35,46 @@ public class ConfigWindow : WindowWrapper {
         WindowDrawHelpers.DrawTooltip(tooltip);
     }
 
-    public override void Draw() {
+    public override void Draw()
+    {
         VirtualKey key;
         float charwidth = ImGui.CalcTextSize("FF").X;
         bool changed = false;
 
-        if (!Globals.Config.shutUpConfigHelp) {
+        if (!Globals.Config.shutUpConfigHelp)
+        {
             ImGui.TextWrapped("Before using this plugin, I suggest making the following changes to your character config:");
             ImGui.TextWrapped("- Under Character Configuration -> Legacy Type, toggle the option \"Disable camera pivot\" on");
             ImGui.TextWrapped("- Under Character Configuration -> Camera Controls, set the option \"Standard Type Camera Auto-adjustment\" to \"Never\", and subsequently disable \"Enable Y-axis auto-adjustment\"");
             ImGui.TextWrapped("Additionally, you should try using strafe over turn movement, and vice-versa.");
             ImGui.TextWrapped("This means going into your keybinds and changing your primary movement keys from turn to strafe, and decide which feels the best to use while under the influence of this plugin.");
-            if (ImGui.Button("Ok!")) {
+            if (ImGui.Button("Ok!"))
+            {
                 Globals.Config.shutUpConfigHelp = true;
             }
             ImGui.Separator();
         }
 
         ImGui.TextDisabled("General Settings");
+
+        ImGui.Text("Use");
+        ImGui.SameLine(0);
+        ImGui.SetNextItemWidth(charwidth * 8);
+        if (ImGui.BeginCombo("Movement Mode", Globals.Config.defaultMovementSetting.mode.ToString()))
+        {
+            for (int index = 0; index < (int)MovementMode.Count; index++)
+            {
+                ImGui.SetNextItemWidth(charwidth * 8);
+                if (ImGui.Selectable(((MovementMode)index).ToString(), index == (int)Globals.Config.defaultMovementSetting.mode))
+                {
+                    Globals.Config.defaultMovementSetting.mode = (MovementMode)index;
+                }
+            }
+            ImGui.EndCombo();
+        }
+        ImGui.SameLine(0);
+        ImGui.Text("as default.");
+
         DrawMoveModeConditionOption("auto-run", ref Globals.Config.autorunMoveMode, "When enabled, forces the selected movement mode while auto-running.");
         DrawMoveModeConditionOption("camera rotation", ref Globals.Config.cameraRotateMoveMode, "When enabled, forces the selected movement mode while rotating the camera. This is probably redundant.");
 
@@ -74,14 +101,18 @@ public class ConfigWindow : WindowWrapper {
         }
 
         // Noone should really need to use this, so I'm just gonna hide it behind a config variable
-        if (Globals.Config.ShowExperimental) {
+        if (Globals.Config.ShowExperimental)
+        {
             ImGui.Separator();
             ImGui.TextDisabled("Experimental");
             ImGui.SetNextItemWidth(charwidth * 9);
-            if (ImGui.BeginCombo($"Use turning on camera rotate###turncameraturn", Globals.Config.useTurnOnCameraTurn.ToString())) {
-                for (int index = 0; index < (int)TurnOnCameraTurn.Count; index++) {
+            if (ImGui.BeginCombo($"Use turning on camera rotate###turncameraturn", Globals.Config.useTurnOnCameraTurn.ToString()))
+            {
+                for (int index = 0; index < (int)TurnOnCameraTurn.Count; index++)
+                {
                     ImGui.SetNextItemWidth(charwidth * 8);
-                    if (ImGui.Selectable(((TurnOnCameraTurn)index).ToString(), index == (int)Globals.Config.useTurnOnCameraTurn)) {
+                    if (ImGui.Selectable(((TurnOnCameraTurn)index).ToString(), index == (int)Globals.Config.useTurnOnCameraTurn))
+                    {
                         Globals.Config.useTurnOnCameraTurn = (TurnOnCameraTurn)index;
                         KeybindHook.cameraTurnMode = Globals.Config.useTurnOnCameraTurn;
                         changed = true;
@@ -92,11 +123,14 @@ public class ConfigWindow : WindowWrapper {
             WindowDrawHelpers.DrawTooltip("Tells the game that you are turning instead of strafing when you are turning the camera. You probably want this disabled.");
         }
 
-        if (changed) {
-            if (Globals.Config.useTurnOnFrontpedal == false && Globals.Config.useTurnOnBackpedal == false && Globals.Config.useTurnOnCameraTurn == TurnOnCameraTurn.None && KeybindHook.Enabled) {
+        if (changed)
+        {
+            if (Globals.Config.useTurnOnFrontpedal == false && Globals.Config.useTurnOnBackpedal == false && Globals.Config.useTurnOnCameraTurn == TurnOnCameraTurn.None && KeybindHook.Enabled)
+            {
                 KeybindHook.DisableHook();
             }
-            else if (KeybindHook.Enabled == false) {
+            else if (KeybindHook.Enabled == false)
+            {
                 KeybindHook.EnableHook();
             }
         }
@@ -105,16 +139,20 @@ public class ConfigWindow : WindowWrapper {
 
         ImGui.TextDisabled("Add and remove the keys for legacy mode below");
 
-        for (int index = 0; index < Globals.Config.legacyModeKeyList.Count; index++) {
+        for (int index = 0; index < Globals.Config.legacyModeKeyList.Count; index++)
+        {
             key = Globals.Config.legacyModeKeyList[index];
             ImGui.SetNextItemWidth(charwidth * 4);
-            if (ImGui.BeginCombo("key##" + index.ToString() + "_" + key.ToString(), key.ToString())) {
+            if (ImGui.BeginCombo("key##" + index.ToString() + "_" + key.ToString(), key.ToString()))
+            {
                 VirtualKey[] validKeys = (VirtualKey[])Service.KeyState.GetValidVirtualKeys();
 
-                for (int qndex = 0; qndex < validKeys.Length; qndex++) {
+                for (int qndex = 0; qndex < validKeys.Length; qndex++)
+                {
                     bool selected = key == validKeys[qndex];
                     ImGui.SetNextItemWidth(charwidth * 12);
-                    if (ImGui.Selectable(validKeys[qndex].ToString() + "##dropdown_" + index.ToString() + "_key_" + validKeys[qndex].ToString(), selected)) {
+                    if (ImGui.Selectable(validKeys[qndex].ToString() + "##dropdown_" + index.ToString() + "_key_" + validKeys[qndex].ToString(), selected))
+                    {
                         Globals.Config.legacyModeKeyList[index] = validKeys[qndex];
                     }
                 }
@@ -122,14 +160,16 @@ public class ConfigWindow : WindowWrapper {
             }
             ImGui.SameLine();
             ImGui.SetNextItemWidth(charwidth * 4);
-            if (ImGui.Button("-##dropdown_" + index.ToString() + "_delete")) {
+            if (ImGui.Button("-##dropdown_" + index.ToString() + "_delete"))
+            {
                 Globals.Config.legacyModeKeyList.RemoveAt(index);
                 break;
             }
         }
         ImGui.SameLine();
         ImGui.SetNextItemWidth(charwidth * 4);
-        if (ImGui.Button("+##dropdown_add_new")) {
+        if (ImGui.Button("+##dropdown_add_new"))
+        {
             Globals.Config.legacyModeKeyList.Add(VirtualKey.SPACE);
         }
 

--- a/HybridCamera/Configuration.cs
+++ b/HybridCamera/Configuration.cs
@@ -5,22 +5,19 @@ using System.Collections.Generic;
 
 namespace HybridCamera;
 
-public enum TurnOnCameraTurn
-{
+public enum TurnOnCameraTurn {
     None = 0,
     Turning,
     WithoutTurning,
     Count
 }
 
-public class MoveModeCondition
-{
+public class MoveModeCondition {
     public MovementMode mode = MovementMode.Standard;
     public bool condition = false;
 }
 
-public class Configuration : IPluginConfiguration
-{
+public class Configuration : IPluginConfiguration {
     int IPluginConfiguration.Version { get; set; }
 
     #region Saved configuration values
@@ -37,8 +34,7 @@ public class Configuration : IPluginConfiguration
     public bool HideTooltips;
     #endregion
 
-    public Configuration()
-    {
+    public Configuration() {
         defaultMovementSetting = new MoveModeCondition();
         autorunMoveMode = new MoveModeCondition();
         cameraRotateMoveMode = new MoveModeCondition();
@@ -52,8 +48,7 @@ public class Configuration : IPluginConfiguration
         legacyModeKeyList = new List<VirtualKey>();
     }
 
-    public void Initialize()
-    {
+    public void Initialize() {
         KeybindHook.turnOnFrontpedal = useTurnOnFrontpedal;
         KeybindHook.turnOnBackpedal = useTurnOnBackpedal;
         KeybindHook.cameraTurnMode = useTurnOnCameraTurn;
@@ -69,8 +64,7 @@ public class Configuration : IPluginConfiguration
         }
     }
 
-    public void Save()
-    {
+    public void Save() {
         Service.Interface.SavePluginConfig(this);
     }
 }

--- a/HybridCamera/Configuration.cs
+++ b/HybridCamera/Configuration.cs
@@ -5,22 +5,26 @@ using System.Collections.Generic;
 
 namespace HybridCamera;
 
-public enum TurnOnCameraTurn {
+public enum TurnOnCameraTurn
+{
     None = 0,
     Turning,
     WithoutTurning,
     Count
 }
 
-public class MoveModeCondition {
+public class MoveModeCondition
+{
     public MovementMode mode = MovementMode.Standard;
     public bool condition = false;
 }
 
-public class Configuration : IPluginConfiguration {
+public class Configuration : IPluginConfiguration
+{
     int IPluginConfiguration.Version { get; set; }
 
     #region Saved configuration values
+    public MoveModeCondition defaultMovementSetting;
     public MoveModeCondition autorunMoveMode;
     public MoveModeCondition cameraRotateMoveMode;
     public bool useTurnOnBackpedal;
@@ -33,7 +37,9 @@ public class Configuration : IPluginConfiguration {
     public bool HideTooltips;
     #endregion
 
-    public Configuration() {
+    public Configuration()
+    {
+        defaultMovementSetting = new MoveModeCondition();
         autorunMoveMode = new MoveModeCondition();
         cameraRotateMoveMode = new MoveModeCondition();
         useTurnOnBackpedal = true;
@@ -46,7 +52,8 @@ public class Configuration : IPluginConfiguration {
         legacyModeKeyList = new List<VirtualKey>();
     }
 
-    public void Initialize() {
+    public void Initialize()
+    {
         KeybindHook.turnOnFrontpedal = useTurnOnFrontpedal;
         KeybindHook.turnOnBackpedal = useTurnOnBackpedal;
         KeybindHook.cameraTurnMode = useTurnOnCameraTurn;
@@ -62,7 +69,8 @@ public class Configuration : IPluginConfiguration {
         }
     }
 
-    public void Save() {
+    public void Save()
+    {
         Service.Interface.SavePluginConfig(this);
     }
 }

--- a/HybridCamera/Movement.cs
+++ b/HybridCamera/Movement.cs
@@ -4,42 +4,52 @@ using FFXIVClientStructs.FFXIV.Client.Game.Control;
 
 namespace HybridCamera;
 
-public static class Movement {
-    private static MovementMode CameraMode = MovementMode.Standard;
+public static class Movement
+{
+    private static MovementMode CameraMode = Globals.Config.defaultMovementSetting.mode;
 
-    public static unsafe void UpdateMoveStatePre() {
-        uint mode = (uint)MovementMode.Standard;
+    public static unsafe void UpdateMoveStatePre()
+    {
+        uint mode = (uint)Globals.Config.defaultMovementSetting.mode;
 
-        if (Service.KeyState == null) {
+        if (Service.KeyState == null)
+        {
             return;
         }
 
-        foreach (VirtualKey key in Globals.Config.legacyModeKeyList) {
-            if (Service.KeyState[key]) {
+        foreach (VirtualKey key in Globals.Config.legacyModeKeyList)
+        {
+            if (Service.KeyState[key])
+            {
                 mode = (uint)MovementMode.Legacy;
                 break;
             }
         }
 
-        if (Globals.Config.autorunMoveMode.condition && InputManager.IsAutoRunning()) {
+        if (Globals.Config.autorunMoveMode.condition && InputManager.IsAutoRunning())
+        {
             mode = (uint)Globals.Config.autorunMoveMode.mode;
         }
 
-        if (Globals.Config.cameraRotateMoveMode.condition && Globals.PlayerIsRotatingCamera()) {
+        if (Globals.Config.cameraRotateMoveMode.condition && Globals.PlayerIsRotatingCamera())
+        {
             mode = (uint)Globals.Config.cameraRotateMoveMode.mode;
         }
 
         CameraMode = (MovementMode)mode;
         GameConfig.UiControl.Set("MoveMode", mode);
 
-        if (Service.CameraManager->Camera->Mode == (int)CameraControlMode.FirstPerson) {
+        if (Service.CameraManager->Camera->Mode == (int)CameraControlMode.FirstPerson)
+        {
             GameConfig.UiControl.Set("MoveMode", (int)MovementMode.Standard);
         }
     }
 
     // for stuff which may need to be run after stuff has changed
-    public static void UpdateMoveStatePost() {
-        if ((Globals.Config.useTurnOnFrontpedal || Globals.Config.useTurnOnBackpedal || Globals.Config.useTurnOnCameraTurn != TurnOnCameraTurn.None) && KeybindHook.Enabled == false) {
+    public static void UpdateMoveStatePost()
+    {
+        if ((Globals.Config.useTurnOnFrontpedal || Globals.Config.useTurnOnBackpedal || Globals.Config.useTurnOnCameraTurn != TurnOnCameraTurn.None) && KeybindHook.Enabled == false)
+        {
             KeybindHook.EnableHook();
         }
     }

--- a/HybridCamera/Movement.cs
+++ b/HybridCamera/Movement.cs
@@ -4,52 +4,42 @@ using FFXIVClientStructs.FFXIV.Client.Game.Control;
 
 namespace HybridCamera;
 
-public static class Movement
-{
+public static class Movement {
     private static MovementMode CameraMode = Globals.Config.defaultMovementSetting.mode;
 
-    public static unsafe void UpdateMoveStatePre()
-    {
+    public static unsafe void UpdateMoveStatePre() {
         uint mode = (uint)Globals.Config.defaultMovementSetting.mode;
 
-        if (Service.KeyState == null)
-        {
+        if (Service.KeyState == null) {
             return;
         }
 
-        foreach (VirtualKey key in Globals.Config.legacyModeKeyList)
-        {
-            if (Service.KeyState[key])
-            {
+        foreach (VirtualKey key in Globals.Config.legacyModeKeyList) {
+            if (Service.KeyState[key]) {
                 mode = (uint)MovementMode.Legacy;
                 break;
             }
         }
 
-        if (Globals.Config.autorunMoveMode.condition && InputManager.IsAutoRunning())
-        {
+        if (Globals.Config.autorunMoveMode.condition && InputManager.IsAutoRunning()) {
             mode = (uint)Globals.Config.autorunMoveMode.mode;
         }
 
-        if (Globals.Config.cameraRotateMoveMode.condition && Globals.PlayerIsRotatingCamera())
-        {
+        if (Globals.Config.cameraRotateMoveMode.condition && Globals.PlayerIsRotatingCamera()) {
             mode = (uint)Globals.Config.cameraRotateMoveMode.mode;
         }
 
         CameraMode = (MovementMode)mode;
         GameConfig.UiControl.Set("MoveMode", mode);
 
-        if (Service.CameraManager->Camera->Mode == (int)CameraControlMode.FirstPerson)
-        {
+        if (Service.CameraManager->Camera->Mode == (int)CameraControlMode.FirstPerson) {
             GameConfig.UiControl.Set("MoveMode", (int)MovementMode.Standard);
         }
     }
 
     // for stuff which may need to be run after stuff has changed
-    public static void UpdateMoveStatePost()
-    {
-        if ((Globals.Config.useTurnOnFrontpedal || Globals.Config.useTurnOnBackpedal || Globals.Config.useTurnOnCameraTurn != TurnOnCameraTurn.None) && KeybindHook.Enabled == false)
-        {
+    public static void UpdateMoveStatePost() {
+        if ((Globals.Config.useTurnOnFrontpedal || Globals.Config.useTurnOnBackpedal || Globals.Config.useTurnOnCameraTurn != TurnOnCameraTurn.None) && KeybindHook.Enabled == false) {
             KeybindHook.EnableHook();
         }
     }


### PR DESCRIPTION
Hi, I've loved the idea of your plugin but after using it I found what I think is an issue.
The default movement setting is always reverted to Standard which is fine if that's what you usually use however it creates 2 problems if that's not how you expect the game to function if you're usually set to Legacy.
If you're playing a melee and hit something while running "around" it while holding both mouse buttons to move and have auto face target turned on in your settings your character will aggressively turn instead of just going forward (that's the biggest reason I don't use standard). Another issue is what #2 describes.

To remedy those two issues I found that giving the option to use either Standard or Legacy as the baseline remedies this issue in most cases (being careful with words in case I missed something but so far I haven't been able to reproduce the issue with Legacy set as default).

Hence my pull request today, I'm not very used to touching plugins or C# in general so please do feel free to tell me if anything isn't to your liking